### PR TITLE
Composer requires pcntl extension be installed, and the latest official php-cli images don't enable it

### DIFF
--- a/docker/common/php-fpm/Dockerfile
+++ b/docker/common/php-fpm/Dockerfile
@@ -23,8 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     bcmath \
     soap \
+    pcntl \
     && pecl install redis \
-    && docker-php-ext-enable redis \
+    && docker-php-ext-enable redis pcntl \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 

--- a/docker/development/workspace/Dockerfile
+++ b/docker/development/workspace/Dockerfile
@@ -27,8 +27,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     bcmath \
     soap \
+    pcntl \
     && pecl install redis xdebug \
-    && docker-php-ext-enable redis xdebug\
+    && docker-php-ext-enable redis xdebug pcntl \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Composer requires pcntl extension be installed, and the latest official php-cli images don't enable it by default. Without these composer throws an error which stops the Dockerfile builds.